### PR TITLE
Add Folder Parameter

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,6 +57,10 @@ Alternatively, you can specify a username and password like so::
     FTRACK_SFTP_ACCESSOR_USERNAME=user
     FTRACK_SFTP_ACCESSOR_PASSWORD=**********
 
+The default behaviour is to upload directly to the sftp users home folder. You can specify an optional subfolder which the accessor will use instead::
+
+    FTRACK_SFTP_ACCESSOR_FOLDER=ftrack
+
 .. highlight:: python
 
 And then in your plugin::
@@ -66,8 +70,15 @@ And then in your plugin::
     port = os.getenv("FTRACK_SFTP_ACCESSOR_PORT", 22)
     username = os.getenv("FTRACK_SFTP_ACCESSOR_USERNAME", None)
     password = os.getenv("FTRACK_SFTP_ACCESSOR_PASSWORD", None)
+    folder = os.getenv("FTRACK_SFTP_ACCESSOR_FOLDER", None)
 
-    location.accessor = SFTPAccessor(hostname, username, port=port, password=password)
+    location.accessor = SFTPAccessor(
+        hostname, 
+        username, 
+        port=port, 
+        password=password, 
+        folder=folder
+    )
 
 Uploading Components
 ====================

--- a/ftrack_sftp_accessor/sftp.py
+++ b/ftrack_sftp_accessor/sftp.py
@@ -20,16 +20,19 @@ from ftrack_api.exception import (
 class SFTPAccessor(Accessor):
     """Provide SFTP location access."""
 
-    def __init__(self, host, username, port=22, password=None):
+    def __init__(self, host, username, port=22, password=None, folder=None):
         """Initialise location accessor.
 
         Uses the server credentials specified by *host*, *password*, *port* and *password*
-        to create a sftp connection
+        to create a sftp connection. 
+
+        If specified, *folder* indicates the subfolder where assets are stored
         """
         self._host = host
         self._username = username
         self._password = password
         self._port = port
+        self._folder = folder
         self._sftp = None
         self._ssh = None
         self._logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
@@ -42,6 +45,7 @@ class SFTPAccessor(Accessor):
             self._username,
             self._port,
             self._password,
+            self._folder
         )
 
     @property
@@ -72,6 +76,9 @@ class SFTPAccessor(Accessor):
         self._logger.debug("Initialising SFTP Session")
         if self._sftp is None:
             self._sftp = self.ssh.open_sftp()
+        
+            if self._folder is not None:
+                self._sftp.chdir(self._folder)
 
         return self._sftp
 
@@ -255,4 +262,6 @@ class SFTPAccessor(Accessor):
     def get_url(self, resource_identifier=None):
         """Return url for *resource_identifier*."""
 
+        if self._folder:
+            return f"sftp://{self._host}:{self._port}/{self._prefix}/{resource_identifier}"
         return f"sftp://{self._host}:{self._port}/{resource_identifier}"

--- a/ftrack_sftp_accessor/sftp.py
+++ b/ftrack_sftp_accessor/sftp.py
@@ -263,5 +263,5 @@ class SFTPAccessor(Accessor):
         """Return url for *resource_identifier*."""
 
         if self._folder:
-            return f"sftp://{self._host}:{self._port}/{self._prefix}/{resource_identifier}"
+            return f"sftp://{self._host}:{self._port}/{self._folder}/{resource_identifier}"
         return f"sftp://{self._host}:{self._port}/{resource_identifier}"

--- a/ftrack_sftp_accessor/sftp.py
+++ b/ftrack_sftp_accessor/sftp.py
@@ -24,7 +24,7 @@ class SFTPAccessor(Accessor):
         """Initialise location accessor.
 
         Uses the server credentials specified by *host*, *password*, *port* and *password*
-        to create a sftp connection. 
+        to create a sftp connection.
 
         If specified, *folder* indicates the subfolder where assets are stored
         """
@@ -41,11 +41,7 @@ class SFTPAccessor(Accessor):
     def __deepcopy__(self, memo):
         """Return a new SFTPAccessor instance"""
         return SFTPAccessor(
-            self._host,
-            self._username,
-            self._port,
-            self._password,
-            self._folder
+            self._host, self._username, self._port, self._password, self._folder
         )
 
     @property
@@ -76,7 +72,7 @@ class SFTPAccessor(Accessor):
         self._logger.debug("Initialising SFTP Session")
         if self._sftp is None:
             self._sftp = self.ssh.open_sftp()
-        
+
             if self._folder is not None:
                 self._sftp.chdir(self._folder)
 
@@ -263,5 +259,7 @@ class SFTPAccessor(Accessor):
         """Return url for *resource_identifier*."""
 
         if self._folder:
-            return f"sftp://{self._host}:{self._port}/{self._folder}/{resource_identifier}"
+            return (
+                f"sftp://{self._host}:{self._port}/{self._folder}/{resource_identifier}"
+            )
         return f"sftp://{self._host}:{self._port}/{resource_identifier}"

--- a/plugins/sftp_location.py
+++ b/plugins/sftp_location.py
@@ -29,9 +29,12 @@ def configure_location(event):
     port = os.getenv("FTRACK_SFTP_ACCESSOR_PORT", 22)
     username = os.getenv("FTRACK_SFTP_ACCESSOR_USERNAME", None)
     password = os.getenv("FTRACK_SFTP_ACCESSOR_PASSWORD", None)
+    folder = os.getenv("FTRACK_SFTP_ACCESSOR_FOLDER", None)
 
     # Setup accessor to use bucket
-    location.accessor = SFTPAccessor(hostname, username, port=port, password=password)
+    location.accessor = SFTPAccessor(
+        hostname, username, port=port, password=password, folder=folder
+    )
     location.structure = ftrack_api.structure.standard.StandardStructure()
     location.priority = 30
 

--- a/scripts/sftp_download.py
+++ b/scripts/sftp_download.py
@@ -16,8 +16,9 @@ sftp_location = session.ensure("Location", {"name": "studio.sftp"})
 hostname = os.getenv("FTRACK_SFTP_ACCESSOR_HOSTNAME", None)
 username = os.getenv("FTRACK_SFTP_ACCESSOR_USERNAME", None)
 port = os.getenv("FTRACK_SFTP_ACCESSOR_PORT", 22)
+folder = os.getenv("FTRACK_SFTP_ACCESSOR_FOLDER", "ftrack")
 
-sftp_location.accessor = SFTPAccessor(hostname, username, port=port)
+sftp_location.accessor = SFTPAccessor(hostname, username, port=port, folder=folder)
 sftp_location.structure = ftrack_api.structure.standard.StandardStructure()
 sftp_location.priority = 30
 

--- a/scripts/sftp_upload.py
+++ b/scripts/sftp_upload.py
@@ -12,9 +12,10 @@ location = session.query('Location where name is "studio.sftp"').one()
 hostname = os.getenv("FTRACK_SFTP_ACCESSOR_HOSTNAME", None)
 username = os.getenv("FTRACK_SFTP_ACCESSOR_USERNAME", None)
 port = os.getenv("FTRACK_SFTP_ACCESSOR_PORT", 22)
+folder = os.getenv("FTRACK_SFTP_ACCESSOR_FOLDER", "ftrack")
 
 # Setup accessor
-location.accessor = SFTPAccessor(hostname, username, port=port)
+location.accessor = SFTPAccessor(hostname, username, port=port, folder=folder)
 location.structure = ftrack_api.structure.standard.StandardStructure()
 location.priority = 30
 


### PR DESCRIPTION
## Changes

Adds a folder parameter, to allow assets to be exchanged within subfolders rather than the home directory of the sftp user.

## Test

Use the existing scripts supplied with the new 'folder' parameter to confirm that assets are uploaded to the correct sftp directory.
